### PR TITLE
Adding changes suggested by Mandiant

### DIFF
--- a/host-interaction/process/dump/create-process-memory-minidump.yml
+++ b/host-interaction/process/dump/create-process-memory-minidump.yml
@@ -6,7 +6,7 @@ rule:
     author: michael.hunhoff@mandiant.com
     scope: basic block
     mbc:
-      - Process::Create Process [C0017]
+      - File System::Write File [C0052]
     examples:
       - 91a12a4cf437589ba70b1687f5acad19:0x43E1C9
   features:

--- a/linking/runtime-linking/resolve-function-by-fin8-fasthash.yml
+++ b/linking/runtime-linking/resolve-function-by-fin8-fasthash.yml
@@ -5,7 +5,8 @@ rule:
     author: "@r3c0nst (Frank Boldewin)"
     description: APIHashing algorithm derived from a fasthash implementation in OpenCPN using seeds
     scope: function
-    mbc: Cryptography::Cryptographic Hash [C0029]
+    mbc: 
+      - Cryptography::Cryptographic Hash [C0029]
     references:
       - https://www.bitdefender.com/files/News/CaseStudies/study/394/Bitdefender-PR-Whitepaper-BADHATCH-creat5237-en-EN.pdf
       - https://raw.githubusercontent.com/fboldewin/YARA-rules/master/Shellcode.APIHashing.FIN8.yar


### PR DESCRIPTION
Per mr-tz of mandiant:

**host-interaction/process/dump/create-process-memory-minidump.yml**
MiniDumpWriteDump writes to a file instead of creating a process. I suggest to change this.

**linking/runtime-linking/resolve-function-by-fin8-fasthash.yml**
format error